### PR TITLE
Saved meal presets (Quick add) + release 0.1.3

### DIFF
--- a/.fdroid.yml
+++ b/.fdroid.yml
@@ -39,8 +39,18 @@ Builds:
       NonFreeNet:
         en-US: Food photo analysis sends images to OpenRouter when the user explicitly
           starts analysis.
+  - versionName: 0.1.3
+    versionCode: 4
+    commit: v0.1.3
+    subdir: app
+    gradle:
+      - yes
+    antifeatures:
+      NonFreeNet:
+        en-US: Food photo analysis sends images to OpenRouter when the user explicitly
+          starts analysis.
 
 AutoUpdateMode: None
 UpdateCheckMode: None
-CurrentVersion: 0.1.2
-CurrentVersionCode: 3
+CurrentVersion: 0.1.3
+CurrentVersionCode: 4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.kbul.spicycrab"
         minSdk = 26
         targetSdk = 35
-        versionCode = 3
-        versionName = "0.1.2"
+        versionCode = 4
+        versionName = "0.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/app/schemas/com.kbul.spicycrab.data.db.AppDatabase/6.json
+++ b/app/schemas/com.kbul.spicycrab.data.db.AppDatabase/6.json
@@ -1,0 +1,360 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "aa644ce9482eba76677f49f5923546b2",
+    "entities": [
+      {
+        "tableName": "fast_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modeName` TEXT NOT NULL, `targetSeconds` INTEGER NOT NULL, `eatingWindowSeconds` INTEGER NOT NULL, `startEpoch` INTEGER NOT NULL, `endEpoch` INTEGER, `completed` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modeName",
+            "columnName": "modeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSeconds",
+            "columnName": "targetSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eatingWindowSeconds",
+            "columnName": "eatingWindowSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startEpoch",
+            "columnName": "startEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endEpoch",
+            "columnName": "endEpoch",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "food_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestampEpoch` INTEGER NOT NULL, `lastModifiedEpoch` INTEGER NOT NULL, `itemName` TEXT NOT NULL, `grams` REAL NOT NULL, `kcal` REAL NOT NULL, `proteinG` REAL NOT NULL, `carbsG` REAL NOT NULL, `fatG` REAL NOT NULL, `fiberG` REAL NOT NULL, `comment` TEXT NOT NULL, `modelUsed` TEXT NOT NULL, `confidence` TEXT NOT NULL, `imagePath` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpoch",
+            "columnName": "timestampEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedEpoch",
+            "columnName": "lastModifiedEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemName",
+            "columnName": "itemName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "grams",
+            "columnName": "grams",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kcal",
+            "columnName": "kcal",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinG",
+            "columnName": "proteinG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carbsG",
+            "columnName": "carbsG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fatG",
+            "columnName": "fatG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fiberG",
+            "columnName": "fiberG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelUsed",
+            "columnName": "modelUsed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "imagePath",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "weight_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestampEpoch` INTEGER NOT NULL, `lastModifiedEpoch` INTEGER NOT NULL, `weightKg` REAL NOT NULL, `note` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpoch",
+            "columnName": "timestampEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedEpoch",
+            "columnName": "lastModifiedEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weightKg",
+            "columnName": "weightKg",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "workout_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `modeName` TEXT NOT NULL, `startEpoch` INTEGER NOT NULL, `endEpoch` INTEGER, `totalSeconds` INTEGER NOT NULL, `intervalSeconds` INTEGER NOT NULL, `exerciseSeconds` INTEGER NOT NULL, `restSeconds` INTEGER NOT NULL, `notes` TEXT NOT NULL, `lastModifiedEpoch` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modeName",
+            "columnName": "modeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startEpoch",
+            "columnName": "startEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endEpoch",
+            "columnName": "endEpoch",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalSeconds",
+            "columnName": "totalSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervalSeconds",
+            "columnName": "intervalSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseSeconds",
+            "columnName": "exerciseSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restSeconds",
+            "columnName": "restSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedEpoch",
+            "columnName": "lastModifiedEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "meal_presets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `grams` REAL NOT NULL, `kcal` REAL NOT NULL, `proteinG` REAL NOT NULL, `carbsG` REAL NOT NULL, `fatG` REAL NOT NULL, `fiberG` REAL NOT NULL, `comment` TEXT NOT NULL, `createdEpoch` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "grams",
+            "columnName": "grams",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kcal",
+            "columnName": "kcal",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinG",
+            "columnName": "proteinG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carbsG",
+            "columnName": "carbsG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fatG",
+            "columnName": "fatG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fiberG",
+            "columnName": "fiberG",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdEpoch",
+            "columnName": "createdEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'aa644ce9482eba76677f49f5923546b2')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/kbul/spicycrab/data/db/Migration56Test.kt
+++ b/app/src/androidTest/java/com/kbul/spicycrab/data/db/Migration56Test.kt
@@ -1,0 +1,57 @@
+package com.kbul.spicycrab.data.db
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class Migration56Test {
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java,
+    )
+
+    @Test
+    fun migrate5To6AddsMealPresetsAndPreservesFood() {
+        val dbName = "migration-5-6-test"
+        helper.createDatabase(dbName, 5).apply {
+            insertFood(id = 3, name = "Chicken & rice", kcal = 540.0)
+            close()
+        }
+
+        val migrated = helper.runMigrationsAndValidate(dbName, 6, true, MIGRATION_5_6)
+
+        migrated.query("SELECT id, itemName, kcal FROM food_entries").use { cursor ->
+            check(cursor.moveToFirst())
+            check(cursor.getLong(0) == 3L)
+            check(cursor.getString(1) == "Chicken & rice")
+            check(cursor.getDouble(2) == 540.0)
+        }
+
+        migrated.execSQL(
+            "INSERT INTO meal_presets (id, name, grams, kcal, proteinG, carbsG, fatG, fiberG, comment, createdEpoch) " +
+                "VALUES (1, 'Prep meal A', 400.0, 620.0, 50.0, 60.0, 18.0, 8.0, 'batch cooked', 1000)"
+        )
+        migrated.query("SELECT name, kcal FROM meal_presets WHERE id = 1").use { cursor ->
+            check(cursor.moveToFirst())
+            check(cursor.getString(0) == "Prep meal A")
+            check(cursor.getDouble(1) == 620.0)
+        }
+        migrated.close()
+    }
+}
+
+private fun SupportSQLiteDatabase.insertFood(id: Long, name: String, kcal: Double) {
+    execSQL(
+        "INSERT INTO food_entries (id, timestampEpoch, lastModifiedEpoch, itemName, grams, kcal, " +
+            "proteinG, carbsG, fatG, fiberG, comment, modelUsed, confidence, imagePath) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        arrayOf(id, 1_000L, 1_000L, name, 300.0, kcal, 40.0, 50.0, 12.0, 5.0, "", "manual", "user", null),
+    )
+}

--- a/app/src/main/java/com/kbul/spicycrab/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/kbul/spicycrab/data/db/AppDatabase.kt
@@ -4,16 +4,18 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.kbul.spicycrab.data.db.dao.FastSessionDao
 import com.kbul.spicycrab.data.db.dao.FoodEntryDao
+import com.kbul.spicycrab.data.db.dao.MealPresetDao
 import com.kbul.spicycrab.data.db.dao.WeightEntryDao
 import com.kbul.spicycrab.data.db.dao.WorkoutSessionDao
 import com.kbul.spicycrab.data.db.entities.FastSession
 import com.kbul.spicycrab.data.db.entities.FoodEntry
+import com.kbul.spicycrab.data.db.entities.MealPreset
 import com.kbul.spicycrab.data.db.entities.WeightEntry
 import com.kbul.spicycrab.data.db.entities.WorkoutSession
 
 @Database(
-    entities = [FastSession::class, FoodEntry::class, WeightEntry::class, WorkoutSession::class],
-    version = 5,
+    entities = [FastSession::class, FoodEntry::class, WeightEntry::class, WorkoutSession::class, MealPreset::class],
+    version = 6,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -21,4 +23,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun foodEntryDao(): FoodEntryDao
     abstract fun weightEntryDao(): WeightEntryDao
     abstract fun workoutSessionDao(): WorkoutSessionDao
+    abstract fun mealPresetDao(): MealPresetDao
 }

--- a/app/src/main/java/com/kbul/spicycrab/data/db/Migrations.kt
+++ b/app/src/main/java/com/kbul/spicycrab/data/db/Migrations.kt
@@ -10,6 +10,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
  *   v3: food_entries gains lastModifiedEpoch
  *   v4: + workout_sessions
  *   v5: weight_entries gains lastModifiedEpoch
+ *   v6: + meal_presets
  *
  * Early development used `fallbackToDestructiveMigration()`, so v1–v3 schema
  * JSONs were never exported. The migrations below exist as defensive paths
@@ -143,4 +144,25 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
     }
 }
 
-val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS meal_presets (
+                id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                grams REAL NOT NULL,
+                kcal REAL NOT NULL,
+                proteinG REAL NOT NULL,
+                carbsG REAL NOT NULL,
+                fatG REAL NOT NULL,
+                fiberG REAL NOT NULL,
+                comment TEXT NOT NULL,
+                createdEpoch INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+    }
+}
+
+val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)

--- a/app/src/main/java/com/kbul/spicycrab/data/db/dao/MealPresetDao.kt
+++ b/app/src/main/java/com/kbul/spicycrab/data/db/dao/MealPresetDao.kt
@@ -1,0 +1,22 @@
+package com.kbul.spicycrab.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kbul.spicycrab.data.db.entities.MealPreset
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MealPresetDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(preset: MealPreset): Long
+
+    @Delete
+    suspend fun delete(preset: MealPreset)
+
+    @Query("SELECT * FROM meal_presets ORDER BY createdEpoch DESC")
+    fun observeAll(): Flow<List<MealPreset>>
+}

--- a/app/src/main/java/com/kbul/spicycrab/data/db/entities/MealPreset.kt
+++ b/app/src/main/java/com/kbul/spicycrab/data/db/entities/MealPreset.kt
@@ -1,0 +1,18 @@
+package com.kbul.spicycrab.data.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "meal_presets")
+data class MealPreset(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val grams: Double,
+    val kcal: Double,
+    val proteinG: Double,
+    val carbsG: Double,
+    val fatG: Double,
+    val fiberG: Double,
+    val comment: String,
+    val createdEpoch: Long,
+)

--- a/app/src/main/java/com/kbul/spicycrab/di/DatabaseModule.kt
+++ b/app/src/main/java/com/kbul/spicycrab/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import com.kbul.spicycrab.data.db.ALL_MIGRATIONS
 import com.kbul.spicycrab.data.db.AppDatabase
 import com.kbul.spicycrab.data.db.dao.FastSessionDao
 import com.kbul.spicycrab.data.db.dao.FoodEntryDao
+import com.kbul.spicycrab.data.db.dao.MealPresetDao
 import com.kbul.spicycrab.data.db.dao.WeightEntryDao
 import com.kbul.spicycrab.data.db.dao.WorkoutSessionDao
 import dagger.Module
@@ -37,4 +38,7 @@ object DatabaseModule {
 
     @Provides
     fun provideWorkoutSessionDao(db: AppDatabase): WorkoutSessionDao = db.workoutSessionDao()
+
+    @Provides
+    fun provideMealPresetDao(db: AppDatabase): MealPresetDao = db.mealPresetDao()
 }

--- a/app/src/main/java/com/kbul/spicycrab/domain/nutrition/FoodRepository.kt
+++ b/app/src/main/java/com/kbul/spicycrab/domain/nutrition/FoodRepository.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.net.Uri
 import com.kbul.spicycrab.data.csv.CsvExporter
 import com.kbul.spicycrab.data.db.dao.FoodEntryDao
+import com.kbul.spicycrab.data.db.dao.MealPresetDao
 import com.kbul.spicycrab.data.db.entities.FoodEntry
+import com.kbul.spicycrab.data.db.entities.MealPreset
 import com.kbul.spicycrab.data.prefs.SecureKeyStore
 import com.kbul.spicycrab.data.prefs.SettingsRepo
 import com.kbul.spicycrab.network.OpenRouterClient
@@ -26,6 +28,7 @@ object FoodAnalysisModels {
 @Singleton
 class FoodRepository @Inject constructor(
     private val dao: FoodEntryDao,
+    private val presetDao: MealPresetDao,
     private val client: OpenRouterClient,
     private val keyStore: SecureKeyStore,
     private val settings: SettingsRepo,
@@ -115,15 +118,59 @@ class FoodRepository @Inject constructor(
 
     suspend fun addManual(draft: FoodEntry): FoodEntry {
         val now = System.currentTimeMillis()
-        val entry = draft.copy(
-            timestampEpoch = now,
-            lastModifiedEpoch = now,
-            modelUsed = "manual",
-            confidence = "user",
-            imagePath = null,
+        return insertAndExport(
+            draft.copy(
+                timestampEpoch = now,
+                lastModifiedEpoch = now,
+                modelUsed = "manual",
+                confidence = "user",
+                imagePath = null,
+            )
         )
-        val id = dao.insert(entry)
-        val saved = entry.copy(id = id)
+    }
+
+    fun observePresets(): Flow<List<MealPreset>> = presetDao.observeAll()
+
+    suspend fun saveAsPreset(source: FoodEntry, name: String): MealPreset {
+        val preset = MealPreset(
+            name = name.ifBlank { source.itemName }.trim(),
+            grams = source.grams,
+            kcal = source.kcal,
+            proteinG = source.proteinG,
+            carbsG = source.carbsG,
+            fatG = source.fatG,
+            fiberG = source.fiberG,
+            comment = source.comment,
+            createdEpoch = System.currentTimeMillis(),
+        )
+        return preset.copy(id = presetDao.insert(preset))
+    }
+
+    suspend fun deletePreset(preset: MealPreset) = presetDao.delete(preset)
+
+    suspend fun logPreset(preset: MealPreset): FoodEntry {
+        val now = System.currentTimeMillis()
+        return insertAndExport(
+            FoodEntry(
+                timestampEpoch = now,
+                lastModifiedEpoch = now,
+                itemName = preset.name,
+                grams = preset.grams,
+                kcal = preset.kcal,
+                proteinG = preset.proteinG,
+                carbsG = preset.carbsG,
+                fatG = preset.fatG,
+                fiberG = preset.fiberG,
+                comment = preset.comment,
+                modelUsed = "preset",
+                confidence = "user",
+                imagePath = null,
+            )
+        )
+    }
+
+    private suspend fun insertAndExport(entry: FoodEntry): FoodEntry {
+        val saved = entry.copy(id = dao.insert(entry))
         settings.current().exportFolderUri?.let { uriStr ->
             csvExporter.appendFoodEntry(Uri.parse(uriStr), saved)
         }

--- a/app/src/main/java/com/kbul/spicycrab/ui/food/EditFoodSheet.kt
+++ b/app/src/main/java/com/kbul/spicycrab/ui/food/EditFoodSheet.kt
@@ -39,6 +39,7 @@ fun EditFoodSheet(
     onSave: (FoodEntry) -> Unit,
     onDelete: (FoodEntry) -> Unit,
     onReanalyze: (String) -> Unit,
+    onSaveAsPreset: (FoodEntry) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -101,6 +102,13 @@ fun EditFoodSheet(
                     modifier = Modifier.weight(1f).height(56.dp),
                 ) { Text("Save") }
             }
+            var presetSaved by remember(draft.itemName) { mutableStateOf(false) }
+            OutlinedButton(
+                onClick = { onSaveAsPreset(draft); presetSaved = true },
+                enabled = draft.itemName.isNotBlank() && !presetSaved,
+                modifier = Modifier.fillMaxWidth().height(48.dp),
+            ) { Text(if (presetSaved) "Saved to quick add ✓" else "Save as preset") }
+
             TextButton(
                 onClick = { onDelete(entry) },
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/kbul/spicycrab/ui/food/FoodScreen.kt
+++ b/app/src/main/java/com/kbul/spicycrab/ui/food/FoodScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kbul.spicycrab.data.db.entities.FoodEntry
+import com.kbul.spicycrab.data.db.entities.MealPreset
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -36,15 +37,19 @@ fun FoodScreen(viewModel: FoodViewModel = hiltViewModel()) {
     val mode by viewModel.mode.collectAsStateWithLifecycle()
     val analyze by viewModel.analyze.collectAsStateWithLifecycle()
     val entries by viewModel.entries.collectAsStateWithLifecycle()
+    val presets by viewModel.presets.collectAsStateWithLifecycle()
     val editing by viewModel.editing.collectAsStateWithLifecycle()
     val manualOpen by viewModel.manualOpen.collectAsStateWithLifecycle()
 
     when (val m = mode) {
         FoodUiMode.List -> FoodListContent(
             entries = entries,
+            presets = presets,
             onAddClick = { viewModel.goToCapture() },
             onManualClick = { viewModel.openManual() },
             onRowClick = viewModel::openEdit,
+            onLogPreset = viewModel::logPreset,
+            onDeletePreset = viewModel::deletePreset,
         )
         FoodUiMode.Capture -> CaptureScreen(
             onCaptured = viewModel::onCaptured,
@@ -67,6 +72,7 @@ fun FoodScreen(viewModel: FoodViewModel = hiltViewModel()) {
             onSave = viewModel::saveEdit,
             onDelete = viewModel::deleteEntry,
             onReanalyze = viewModel::reanalyzeEdit,
+            onSaveAsPreset = viewModel::saveAsPreset,
             onDismiss = viewModel::dismissEdit,
         )
     }
@@ -74,6 +80,7 @@ fun FoodScreen(viewModel: FoodViewModel = hiltViewModel()) {
     if (manualOpen) {
         ManualFoodSheet(
             onSave = viewModel::saveManual,
+            onSaveAsPreset = viewModel::saveAsPreset,
             onDismiss = viewModel::dismissManual,
         )
     }
@@ -82,9 +89,12 @@ fun FoodScreen(viewModel: FoodViewModel = hiltViewModel()) {
 @Composable
 private fun FoodListContent(
     entries: List<FoodEntry>,
+    presets: List<MealPreset>,
     onAddClick: () -> Unit,
     onManualClick: () -> Unit,
     onRowClick: (FoodEntry) -> Unit,
+    onLogPreset: (MealPreset) -> Unit,
+    onDeletePreset: (MealPreset) -> Unit,
 ) {
     Scaffold(
         floatingActionButton = {
@@ -106,24 +116,32 @@ private fun FoodListContent(
             }
         }
     ) { padding ->
-        if (entries.isEmpty()) {
-            Box(
-                Modifier.fillMaxSize().padding(padding).padding(24.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    "No meals logged yet. Analyze a photo or add a manual meal.",
-                    style = MaterialTheme.typography.bodyLarge,
-                )
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            QuickAddRow(
+                presets = presets,
+                onLog = onLogPreset,
+                onDelete = onDeletePreset,
+                modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+            )
+            if (entries.isEmpty()) {
+                Box(
+                    Modifier.fillMaxSize().padding(24.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "No meals logged yet. Analyze a photo or add a manual meal.",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+                return@Column
             }
-            return@Scaffold
-        }
-        LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 12.dp),
-        ) {
-            items(entries, key = { it.id }) { entry -> FoodRow(entry, onClick = { onRowClick(entry) }) }
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 12.dp),
+            ) {
+                items(entries, key = { it.id }) { entry -> FoodRow(entry, onClick = { onRowClick(entry) }) }
+            }
         }
     }
 }

--- a/app/src/main/java/com/kbul/spicycrab/ui/food/FoodViewModel.kt
+++ b/app/src/main/java/com/kbul/spicycrab/ui/food/FoodViewModel.kt
@@ -3,6 +3,7 @@ package com.kbul.spicycrab.ui.food
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kbul.spicycrab.data.db.entities.FoodEntry
+import com.kbul.spicycrab.data.db.entities.MealPreset
 import com.kbul.spicycrab.domain.nutrition.FoodRepository
 import com.kbul.spicycrab.domain.nutrition.NutritionEstimate
 import kotlinx.coroutines.flow.asStateFlow
@@ -55,6 +56,9 @@ class FoodViewModel @Inject constructor(
     val manualOpen: StateFlow<Boolean> = _manualOpen.asStateFlow()
 
     val entries: StateFlow<List<FoodEntry>> = repository.observeAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val presets: StateFlow<List<MealPreset>> = repository.observePresets()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun goToCapture() {
@@ -133,6 +137,19 @@ class FoodViewModel @Inject constructor(
             repository.delete(entry)
             _editing.value = null
         }
+    }
+
+    fun logPreset(preset: MealPreset) {
+        viewModelScope.launch { repository.logPreset(preset) }
+    }
+
+    fun deletePreset(preset: MealPreset) {
+        viewModelScope.launch { repository.deletePreset(preset) }
+    }
+
+    fun saveAsPreset(source: FoodEntry) {
+        if (source.itemName.isBlank()) return
+        viewModelScope.launch { repository.saveAsPreset(source, source.itemName) }
     }
 
     fun openManual() { _manualOpen.value = true }

--- a/app/src/main/java/com/kbul/spicycrab/ui/food/ManualFoodSheet.kt
+++ b/app/src/main/java/com/kbul/spicycrab/ui/food/ManualFoodSheet.kt
@@ -31,6 +31,7 @@ import com.kbul.spicycrab.data.db.entities.FoodEntry
 @Composable
 fun ManualFoodSheet(
     onSave: (FoodEntry) -> Unit,
+    onSaveAsPreset: (FoodEntry) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -90,6 +91,12 @@ fun ManualFoodSheet(
                     modifier = Modifier.weight(1f).height(56.dp),
                 ) { Text("Save meal") }
             }
+            var presetSaved by remember(draft.itemName) { mutableStateOf(false) }
+            OutlinedButton(
+                onClick = { onSaveAsPreset(draft); presetSaved = true },
+                enabled = canSave && !presetSaved,
+                modifier = Modifier.fillMaxWidth().height(48.dp),
+            ) { Text(if (presetSaved) "Saved to quick add ✓" else "Save as preset") }
         }
     }
 }

--- a/app/src/main/java/com/kbul/spicycrab/ui/food/QuickAddRow.kt
+++ b/app/src/main/java/com/kbul/spicycrab/ui/food/QuickAddRow.kt
@@ -1,0 +1,89 @@
+package com.kbul.spicycrab.ui.food
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.kbul.spicycrab.data.db.entities.MealPreset
+
+@Composable
+fun QuickAddRow(
+    presets: List<MealPreset>,
+    onLog: (MealPreset) -> Unit,
+    onDelete: (MealPreset) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (presets.isEmpty()) return
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+            "Quick add",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+        ) {
+            items(presets, key = { it.id }) { preset ->
+                PresetChip(preset, onLog = { onLog(preset) }, onDelete = { onDelete(preset) })
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun PresetChip(preset: MealPreset, onLog: () -> Unit, onDelete: () -> Unit) {
+    var confirmDelete by remember { mutableStateOf(false) }
+
+    ElevatedCard(
+        Modifier.combinedClickable(onClick = onLog, onLongClick = { confirmDelete = true })
+    ) {
+        Column(Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(
+                preset.name,
+                style = MaterialTheme.typography.titleSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                "${preset.kcal.toInt()} kcal · P${preset.proteinG.toInt()} / C${preset.carbsG.toInt()} / F${preset.fatG.toInt()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
+    if (confirmDelete) {
+        AlertDialog(
+            onDismissRequest = { confirmDelete = false },
+            title = { Text("Delete preset?") },
+            text = { Text("Remove “${preset.name}” from quick add. Meals you already logged are not affected.") },
+            confirmButton = {
+                TextButton(onClick = { onDelete(); confirmDelete = false }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = { TextButton(onClick = { confirmDelete = false }) { Text("Cancel") } },
+        )
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,1 @@
+Saved meal presets: turn any logged or manual meal into a one-tap "Quick add" button on the Food screen. Great for prepped meals you eat repeatedly, with no photo or AI call. Long-press a preset to remove it.


### PR DESCRIPTION
## Summary
Adds **saved meal presets** — the open meal-prep feature request. Any logged or manual meal becomes a one-tap **Quick add** chip at the top of the Food screen. Tapping logs the meal instantly with no photo or API call; long-press removes the preset without affecting meals already logged.

Also bumps the app to **0.1.3** for release (the train that also carries the new F-Droid listing icon + metadata already on `main`).

## What's included
- **Data:** new `MealPreset` entity + `MealPresetDao`; DB v5 → v6 with `MIGRATION_5_6`, exported `6.json` schema, and `Migration56Test`.
- **Domain:** `FoodRepository` gains `observePresets / saveAsPreset / deletePreset / logPreset`; preset logging reuses the manual insert + CSV-export path (shared `insertAndExport` helper), so dashboard totals and exports work unchanged.
- **UI:** `QuickAddRow` chips (tap = log, long-press = delete with confirm); "Save as preset" added to the edit and manual sheets.
- **Release:** `versionCode 4` / `versionName 0.1.3`, changelog `4.txt`, and a `v0.1.3` build entry in `.fdroid.yml`.

## Verified on emulator (Pixel 7 Pro)
Save-as-preset → chip appears → tap logs the meal → long-press deletes the preset (logged meal preserved) → meal counts toward the Home dashboard total. No new permissions, no network, fully local.

## Release follow-up (after merge)
`.fdroid.yml` pins the new build to tag **`v0.1.3`** — create that tag on `main` after merge so F-Droid builds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
